### PR TITLE
Portfolio redesign — premium UX, content overhaul, mobile-first

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,5 @@
+# Contact form (Formspree)
+# 1. Sign up free at https://formspree.io
+# 2. Create a new form — copy the ID shown (e.g. "xpzgvkab")
+# 3. Paste it below, then rename this file to .env.local
+NEXT_PUBLIC_FORMSPREE_ID=your_form_id_here

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,27 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── iOS safe area for mobile bottom nav ── */
+@supports (padding-bottom: env(safe-area-inset-bottom)) {
+  .pb-safe {
+    padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
+  }
+}
+
+/* ── Navbar: hamburger menu lines ── */
+.hamburger-line {
+  @apply absolute left-0 w-6 h-0.5 bg-current transition-all duration-300;
+}
+
+/* ── Navbar: glow animation ── */
+@keyframes glow {
+  0%, 100% { opacity: 0.2; }
+  50%       { opacity: 0.4; }
+}
+.nav-glow {
+  animation: glow 2s ease-in-out infinite;
+}
+
 /* ── Performance: promote animated elements to their own composite layer ── */
 .animate-pulse,
 .animate-bounce,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,25 +7,29 @@ import Footer from "../../src/components/shared/Footer";
 import { ThemeProvider } from "../../src/components/shared/ThemeProvider";
 import ScrollToTopButton from "../../src/components/shared/ScrollToTopButton";
 import PageLoader from "../../src/components/shared/PageLoader";
-import FloatingContactButton from "../../src/components/shared/FloatingContactButton";
+import AvailabilityBar from "../../src/components/shared/AvailabilityBar";
+import MobileBottomNav from "../../src/components/shared/MobileBottomNav";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Samir Kadu - Professional Portfolio",
-  description: "Samir Kadu's professional portfolio showcasing his skills, projects, and experience in software development.",
-  keywords: "Samir Kadu, portfolio, software developer, web developer, full-stack, frontend, backend, React, Next.js, JavaScript, TypeScript, Python",
+  title: "Samir Kadu — Full Stack Engineer & QA Automation Specialist",
+  description:
+    "Samir Kadu builds reliable, production-grade web applications and automated test systems. 3+ years at Bajaj Finserv Health. AWS Certified.",
+  keywords:
+    "Samir Kadu, Full Stack Developer, QA Automation Engineer, React, Next.js, TypeScript, Spring Boot, Selenium, Playwright, AWS, Bajaj Finserv Health, portfolio",
   openGraph: {
-    title: "Samir Kadu - Professional Portfolio",
-    description: "Samir Kadu's professional portfolio showcasing his skills, projects, and experience in software development.",
-    url: "https://www.samirkadu.com", // Replace with actual URL
-    siteName: "Samir Kadu - Professional Portfolio",
+    title: "Samir Kadu — Full Stack Engineer & QA Automation Specialist",
+    description:
+      "Samir Kadu builds reliable, production-grade web applications and automated test systems. 3+ years at Bajaj Finserv Health. AWS Certified.",
+    url: "https://www.samirkadu.com",
+    siteName: "Samir Kadu",
     images: [
       {
-        url: "https://www.samirkadu.com/og-image.jpg", // Replace with actual URL
+        url: "https://www.samirkadu.com/og-image.jpg",
         width: 1200,
         height: 630,
-        alt: "Samir Kadu - Professional Portfolio",
+        alt: "Samir Kadu — Full Stack Engineer & QA Automation Specialist",
       },
     ],
     locale: "en_US",
@@ -33,10 +37,10 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Samir Kadu - Professional Portfolio",
-    description: "Samir Kadu's professional portfolio showcasing his skills, projects, and experience in software development.",
-    creator: "@SamirKadu", // Replace with actual Twitter handle if available
-    images: ["https://www.samirkadu.com/og-image.jpg"], // Replace with actual URL
+    title: "Samir Kadu — Full Stack Engineer & QA Automation Specialist",
+    description:
+      "Samir Kadu builds reliable, production-grade web applications and automated test systems. 3+ years at Bajaj Finserv Health. AWS Certified.",
+    images: ["https://www.samirkadu.com/og-image.jpg"],
   },
 };
 
@@ -54,12 +58,13 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
+          <AvailabilityBar />
           <PageLoader />
-          
           <Navbar />
-          {children}
+          <div className="lg:pb-0 pb-16">{children}</div>
           <Footer />
           <ScrollToTopButton />
+          <MobileBottomNav />
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@ import AboutMe from "../components/sections/AboutMe";
 import Skills from "../components/sections/Skills";
 import Projects from "../components/sections/Projects";
 import ExperienceEducation from "../components/sections/ExperienceEducation";
-import InterestsHobbies from "../components/sections/InterestsHobbies";
 import ContactMe from "../components/sections/ContactMe";
 import AnimatedSection from "../components/shared/AnimatedSection";
 
@@ -22,9 +21,6 @@ export default function Home() {
       </AnimatedSection>
       <AnimatedSection id="experience">
         <ExperienceEducation />
-      </AnimatedSection>
-      <AnimatedSection id="interests">
-        <InterestsHobbies />
       </AnimatedSection>
       <AnimatedSection id="contact">
         <ContactMe />

--- a/src/components/sections/AboutMe.tsx
+++ b/src/components/sections/AboutMe.tsx
@@ -1,63 +1,44 @@
 "use client";
-import { useState, useEffect, useRef } from "react";
+import { useRef } from "react";
+import { motion, useInView } from "framer-motion";
 import { ABOUT_ME } from "../../lib/constants";
 
+const fadeUp = (delay = 0) => ({
+  hidden: { opacity: 0, y: 28 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.6, ease: [0.0, 0.0, 0.2, 1] as const, delay },
+  },
+});
+
 const AboutMe = () => {
-  const [isVisible, setIsVisible] = useState(false);
-  const [activeTab, setActiveTab] = useState('story');
-  const sectionRef = useRef(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-        }
-      },
-      { threshold: 0.3 }
-    );
-
-    if (sectionRef.current) {
-      observer.observe(sectionRef.current);
-    }
-
-    return () => observer.disconnect();
-  }, []);
-
-  const stats = [
-    { label: "Years of Experience", value: "3+", icon: "🚀" },
-    { label: "Projects Completed", value: "25+", icon: "💼" },
-    { label: "Technologies Mastered", value: "15+", icon: "⚡" },
-    { label: "Happy Clients", value: "10+", icon: "😊" }
-  ];
-
-  const tabs = [
-    { id: 'story', label: 'My Story', content: ABOUT_ME.story },
-    { id: 'goals', label: 'Goals & Vision', content: ABOUT_ME.goals },
-    { id: 'passion', label: 'What Drives Me', content: ABOUT_ME.passion }
-  ];
+  const ref = useRef<HTMLElement>(null);
+  const isInView = useInView(ref, { once: true, amount: 0.15 });
 
   return (
-    <section 
-      ref={sectionRef}
-      id="about" 
-      className="py-20 bg-gradient-to-br from-gray-50/80 via-white/80 to-blue-50/80 dark:from-gray-900/80 dark:via-gray-800/80 dark:to-slate-900/80 relative overflow-hidden"
+    <section
+      ref={ref}
+      id="about"
+      className="py-24 bg-gradient-to-br from-gray-50/80 via-white/80 to-blue-50/80 dark:from-gray-900/80 dark:via-gray-800/80 dark:to-slate-900/80 relative overflow-hidden"
     >
-      {/* Background Pattern */}
-      <div className="absolute inset-0 opacity-5 dark:opacity-10">
-        <div
-          className="absolute inset-0"
-          style={{
-            backgroundImage: `url("data:image/svg+xml,%3Csvg width='100' height='100' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 18c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm48 25c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm-43-7c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm63 31c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM34 90c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm56-76c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3z' fill='%236366f1' fill-opacity='0.4' fill-rule='evenodd'/%3E%3C/svg%3E")`,
-          }}
-        ></div>
-      </div>
-      
+      <div
+        className="absolute inset-0 opacity-[0.03] dark:opacity-[0.06] pointer-events-none"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%236366f1' fill-opacity='1'%3E%3Ccircle cx='30' cy='30' r='1'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
+        }}
+        aria-hidden="true"
+      />
 
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
-        {/* Section Header */}
-        <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}>
-          <div className="inline-flex items-center space-x-2 bg-blue-100 dark:bg-blue-900/30 px-4 py-2 rounded-full text-blue-600 dark:text-blue-400 text-sm font-medium mb-4">
+        {/* Header */}
+        <motion.div
+          className="text-center mb-16"
+          variants={fadeUp(0)}
+          initial="hidden"
+          animate={isInView ? "visible" : "hidden"}
+        >
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-sm font-semibold mb-5">
             <span>👋</span>
             <span>Get to know me</span>
           </div>
@@ -66,64 +47,40 @@ const AboutMe = () => {
               {ABOUT_ME.title}
             </span>
           </h2>
-          <div className="w-24 h-1 bg-gradient-to-r from-blue-600 to-purple-600 mx-auto rounded-full"></div>
-        </div>
+          <div className="w-24 h-1 bg-gradient-to-r from-blue-600 to-purple-600 mx-auto rounded-full" />
+        </motion.div>
 
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
-          {/* Left Side - Content */}
-          <div className={`space-y-8 transition-all duration-1000 delay-300 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'}`}>
-            {/* Tab Navigation */}
-            <div role="tablist" className="flex flex-wrap gap-2 mb-6">
-              {tabs.map((tab) => (
-                <button
-                  key={tab.id}
-                  id={`tab-${tab.id}`}
-                  role="tab"
-                  aria-controls={`panel-${tab.id}`}
-                  aria-selected={activeTab === tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 ${
-                    activeTab === tab.id
-                      ? 'bg-blue-600 text-white shadow-lg transform scale-105'
-                      : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
-                  }`}
-                >
-                  {tab.label}
-                </button>
-              ))}
+        {/* ── Bento grid ── */}
+        <div className="grid lg:grid-cols-5 gap-6 max-w-6xl mx-auto">
+
+          {/* Story — spans 3 cols */}
+          <motion.div
+            className="lg:col-span-3 bg-white dark:bg-gray-800 rounded-2xl p-7 sm:p-8 shadow-lg border border-gray-100 dark:border-gray-700"
+            variants={fadeUp(0.1)}
+            initial="hidden"
+            animate={isInView ? "visible" : "hidden"}
+          >
+            <p className="text-xs font-bold tracking-widest uppercase text-blue-500 dark:text-blue-400 mb-4">My Story</p>
+            {ABOUT_ME.story.split("\n\n").map((para, i) => (
+              <p key={i} className={`text-gray-700 dark:text-gray-300 leading-relaxed text-base ${i > 0 ? "mt-4" : ""}`}>
+                {para}
+              </p>
+            ))}
+
+            <div className="mt-6 pt-5 border-t border-gray-100 dark:border-gray-700">
+              <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+                <span className="font-semibold text-gray-700 dark:text-gray-300">Beyond engineering: </span>
+                {ABOUT_ME.interests}
+              </p>
             </div>
 
-            {/* Tab Content */}
-            <div className="relative min-h-[200px]">
-              {tabs.map((tab) => (
-                <div
-                  key={tab.id}
-                  id={`panel-${tab.id}`}
-                  role="tabpanel"
-                  aria-labelledby={`tab-${tab.id}`}
-                  className={`absolute inset-0 transition-all duration-500 ${
-                    activeTab === tab.id 
-                      ? 'opacity-100 translate-y-0' 
-                      : 'opacity-0 translate-y-4 pointer-events-none'
-                  }`}
-                >
-                  <div className="bg-white dark:bg-gray-800 rounded-2xl p-8 shadow-xl border border-gray-100 dark:border-gray-700">
-                    <p className="text-lg text-gray-700 dark:text-gray-300 leading-relaxed">
-                      {tab.content}
-                    </p>
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            {/* Call to Action */}
-            <div className="flex flex-col sm:flex-row gap-4">
+            <div className="flex flex-col sm:flex-row gap-3 mt-7">
               <a
                 href="#contact"
-                className="inline-flex items-center justify-center px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold rounded-full hover:from-blue-700 hover:to-purple-700 transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
+                className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-full bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold hover:from-blue-700 hover:to-purple-700 transition-all duration-300 hover:scale-105 shadow-lg hover:shadow-xl text-sm"
               >
-                <span>Let's Connect</span>
-                <svg className="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                Let&apos;s Connect
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
                 </svg>
               </a>
@@ -131,73 +88,96 @@ const AboutMe = () => {
                 href="/Samir_Kadu_Resume.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center justify-center px-6 py-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-white font-semibold rounded-full border-2 border-gray-300 dark:border-gray-600 hover:border-blue-500 dark:hover:border-blue-400 transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
+                className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-full bg-white dark:bg-gray-700 text-gray-900 dark:text-white font-semibold border-2 border-gray-200 dark:border-gray-600 hover:border-blue-500 dark:hover:border-blue-400 transition-all duration-300 hover:scale-105 shadow text-sm"
               >
-                <span>Download Resume</span>
-                <svg className="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                 </svg>
+                Download Resume
               </a>
             </div>
-          </div>
+          </motion.div>
 
-          {/* Right Side - Stats & Visual Elements */}
-          <div className={`space-y-8 transition-all duration-1000 delay-500 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-8'}`}>
-            {/* Stats Grid */}
-            <div className="grid grid-cols-2 gap-4">
-              {stats.map((stat, index) => (
+          {/* Right column — 2 cols */}
+          <div className="lg:col-span-2 flex flex-col gap-6">
+
+            {/* Stats 2×2 */}
+            <motion.div
+              className="grid grid-cols-2 gap-3"
+              variants={fadeUp(0.2)}
+              initial="hidden"
+              animate={isInView ? "visible" : "hidden"}
+            >
+              {ABOUT_ME.stats.map((stat, i) => (
                 <div
-                  key={index}
-                  className={`bg-white dark:bg-gray-800 rounded-2xl p-6 text-center shadow-xl border border-gray-100 dark:border-gray-700 transform transition-all duration-500 hover:scale-105 hover:shadow-2xl ${
-                    isVisible ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'
-                  }`}
-                  style={{ transitionDelay: `${600 + index * 100}ms` }}
+                  key={i}
+                  className="bg-white dark:bg-gray-800 rounded-2xl p-4 text-center shadow border border-gray-100 dark:border-gray-700 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300"
                 >
-                  <div className="text-3xl mb-3">{stat.icon}</div>
-                  <div className="text-3xl font-bold text-blue-600 dark:text-blue-400 mb-2">
+                  <div className="text-xl mb-1">{stat.icon}</div>
+                  <div className="text-2xl font-black bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent leading-none mb-1">
                     {stat.value}
                   </div>
-                  <div className="text-sm text-gray-600 dark:text-gray-400 font-medium">
-                    {stat.label}
-                  </div>
+                  <div className="text-[11px] text-gray-500 dark:text-gray-400 font-medium leading-tight">{stat.label}</div>
                 </div>
               ))}
-            </div>
+            </motion.div>
 
-            {/* Personal Highlights */}
-            <div className="bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20 rounded-2xl p-8 border border-blue-100 dark:border-blue-800">
-              <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Quick Facts About Me</h3>
+            {/* Right Now status */}
+            <motion.div
+              className="bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-2xl p-5 border border-blue-100 dark:border-blue-800/50"
+              variants={fadeUp(0.3)}
+              initial="hidden"
+              animate={isInView ? "visible" : "hidden"}
+            >
+              <p className="text-xs font-bold tracking-widest uppercase text-blue-500 dark:text-blue-400 mb-4">Right Now</p>
               <div className="space-y-3">
-                {[
-                  { icon: "🎯", text: "Problem-solving enthusiast" },
-                  { icon: "🌱", text: "Continuous learner" },
-                  { icon: "🤝", text: "Team collaboration focused" },
-                  { icon: "⚡", text: "Performance optimization lover" }
-                ].map((fact, index) => (
-                  <div 
-                    key={index}
-                    className="flex items-center space-x-3 text-gray-700 dark:text-gray-300"
-                  >
-                    <span className="text-xl">{fact.icon}</span>
-                    <span className="font-medium">{fact.text}</span>
+                {ABOUT_ME.currentFocus.map((item, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <span className="text-xs font-bold text-gray-400 dark:text-gray-500 w-20 flex-shrink-0 pt-0.5">{item.label}</span>
+                    <span className="text-xs text-gray-700 dark:text-gray-300 font-medium leading-relaxed">{item.value}</span>
                   </div>
                 ))}
               </div>
-            </div>
+            </motion.div>
 
-            {/* Decorative Element */}
-            <div className="relative">
-              <div className="absolute inset-0 bg-gradient-to-r from-blue-400 to-purple-400 rounded-2xl transform rotate-3 opacity-20"></div>
-              <div className="relative bg-white dark:bg-gray-800 rounded-2xl p-6 text-center shadow-xl border border-gray-100 dark:border-gray-700">
+            {/* Quote */}
+            <motion.div
+              className="relative flex-1"
+              variants={fadeUp(0.4)}
+              initial="hidden"
+              animate={isInView ? "visible" : "hidden"}
+            >
+              <div className="absolute inset-0 bg-gradient-to-r from-blue-400 to-purple-400 rounded-2xl rotate-1 opacity-10" />
+              <div className="relative bg-white dark:bg-gray-800 rounded-2xl p-5 shadow border border-gray-100 dark:border-gray-700 text-center h-full flex flex-col items-center justify-center">
                 <div className="text-2xl mb-2">💡</div>
-                <p className="text-gray-700 dark:text-gray-300 font-medium">
-                  "Code is like humor. When you have to explain it, it's bad."
+                <p className="text-gray-800 dark:text-gray-200 font-semibold italic leading-snug text-sm">
+                  &ldquo;{ABOUT_ME.quote.text}&rdquo;
                 </p>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">- Cory House</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">— {ABOUT_ME.quote.author}</p>
               </div>
-            </div>
+            </motion.div>
           </div>
         </div>
+
+        {/* What defines my work — full width */}
+        <motion.div
+          className="max-w-6xl mx-auto mt-6 bg-white dark:bg-gray-800 rounded-2xl p-6 shadow border border-gray-100 dark:border-gray-700"
+          variants={fadeUp(0.45)}
+          initial="hidden"
+          animate={isInView ? "visible" : "hidden"}
+        >
+          <p className="text-xs font-bold tracking-widest uppercase text-gray-400 dark:text-gray-500 mb-4 text-center">
+            What defines my work
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            {ABOUT_ME.highlights.map((item, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <span className="text-xl flex-shrink-0">{item.icon}</span>
+                <span className="text-gray-700 dark:text-gray-300 font-medium text-sm">{item.text}</span>
+              </div>
+            ))}
+          </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/src/components/sections/ContactMe.tsx
+++ b/src/components/sections/ContactMe.tsx
@@ -2,55 +2,70 @@
 
 import { CONTACT_ME } from "../../lib/constants";
 import { useState, useEffect, useRef } from "react";
+import { MapPin, Clock, Zap, Mail } from "lucide-react";
+
+/**
+ * To activate the contact form:
+ * 1. Sign up free at https://formspree.io
+ * 2. Create a new form → copy the form ID (e.g. "xpzgvkab")
+ * 3. Add to .env.local:  NEXT_PUBLIC_FORMSPREE_ID=xpzgvkab
+ *
+ * Without the env var, the button opens the user's mail client instead.
+ */
+const FORMSPREE_ENDPOINT = process.env.NEXT_PUBLIC_FORMSPREE_ID
+  ? `https://formspree.io/f/${process.env.NEXT_PUBLIC_FORMSPREE_ID}`
+  : null;
 
 const ContactMe = () => {
-  const [formData, setFormData] = useState({
-    name: "",
-    email: "",
-    message: "",
-  });
+  const [formData, setFormData] = useState({ name: "", email: "", message: "" });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
-  const [focusedField, setFocusedField] = useState(null);
-  const [submitStatus, setSubmitStatus] = useState(null);
-  const sectionRef = useRef(null);
+  const [focusedField, setFocusedField] = useState<string | null>(null);
+  const [submitStatus, setSubmitStatus] = useState<'success' | 'error' | null>(null);
+  const sectionRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-        }
-      },
-      { threshold: 0.2 }
+      ([entry]) => { if (entry.isIntersecting) setIsVisible(true); },
+      { threshold: 0.15 }
     );
-
-    if (sectionRef.current) {
-      observer.observe(sectionRef.current);
-    }
-
+    if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
   }, []);
 
-  const handleChange = (e) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
-    
-    // Simulate API call
+
+    if (!FORMSPREE_ENDPOINT) {
+      const subject = encodeURIComponent(`Portfolio contact from ${formData.name}`);
+      const body = encodeURIComponent(`Name: ${formData.name}\nEmail: ${formData.email}\n\n${formData.message}`);
+      window.location.href = `mailto:${CONTACT_ME.email}?subject=${subject}&body=${body}`;
+      setIsSubmitting(false);
+      return;
+    }
+
     try {
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      setSubmitStatus('success');
-      setFormData({ name: "", email: "", message: "" });
-      
-      // Reset status after 3 seconds
-      setTimeout(() => setSubmitStatus(null), 3000);
-    } catch (error) {
+      const res = await fetch(FORMSPREE_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify(formData),
+      });
+      if (res.ok) {
+        setSubmitStatus('success');
+        setFormData({ name: "", email: "", message: "" });
+        setTimeout(() => setSubmitStatus(null), 6000);
+      } else {
+        setSubmitStatus('error');
+        setTimeout(() => setSubmitStatus(null), 6000);
+      }
+    } catch {
       setSubmitStatus('error');
-      setTimeout(() => setSubmitStatus(null), 3000);
+      setTimeout(() => setSubmitStatus(null), 6000);
     } finally {
       setIsSubmitting(false);
     }
@@ -59,272 +74,206 @@ const ContactMe = () => {
   const socialLinks = [
     {
       name: "Email",
-      icon: "📧",
-      href: CONTACT_ME.email ? `mailto:${CONTACT_ME.email}` : "#",
-      color: "from-red-500 to-pink-500",
-      description: "Drop me a line"
+      icon: <Mail className="w-5 h-5" />,
+      href: `mailto:${CONTACT_ME.email}`,
+      color: "from-rose-500 to-pink-600",
+      description: CONTACT_ME.email,
+      external: false,
     },
     {
       name: "LinkedIn",
-      icon: "💼",
-      href: CONTACT_ME.linkedin || "#",
-      color: "from-blue-600 to-blue-800",
-      description: "Let's connect professionally"
+      icon: (
+        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+        </svg>
+      ),
+      href: CONTACT_ME.linkedin,
+      color: "from-blue-600 to-blue-700",
+      description: "Connect professionally",
+      external: true,
     },
     {
       name: "GitHub",
-      icon: "🐱",
-      href: CONTACT_ME.github || "#",
-      color: "from-gray-700 to-gray-900",
-      description: "Check out my code"
+      icon: (
+        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+        </svg>
+      ),
+      href: CONTACT_ME.github,
+      color: "from-gray-700 to-gray-900 dark:from-gray-600 dark:to-gray-800",
+      description: "Browse my code",
+      external: true,
     },
-    // {
-    //   name: "Twitter",
-    //   icon: "🐦",
-    //   href: CONTACT_ME.twitter || "#",
-    //   color: "from-sky-400 to-blue-500",
-    //   description: "Follow my thoughts"
-    // }
   ];
 
+  const floatingLabel = (field: string, value: string) =>
+    `absolute left-4 transition-all duration-300 pointer-events-none ${
+      focusedField === field || value
+        ? '-top-2 text-xs bg-white dark:bg-gray-800 px-2 text-blue-600 dark:text-blue-400 font-semibold'
+        : 'top-4 text-gray-400 dark:text-gray-500 text-sm'
+    }`;
+
   return (
-    <section 
+    <section
       ref={sectionRef}
-      id="contact" 
-      className="py-20 bg-gradient-to-br from-gray-50/80 via-blue-50/80 to-purple-50/80 dark:from-gray-900/80 dark:via-slate-800/80 dark:to-indigo-900/80 relative overflow-hidden"
+      id="contact"
+      className="py-24 bg-gradient-to-br from-gray-50/80 via-blue-50/80 to-purple-50/80 dark:from-gray-900/80 dark:via-slate-800/80 dark:to-indigo-900/80 relative overflow-hidden"
     >
-      {/* Background Elements */}
-      <div className="absolute inset-0 opacity-30" aria-hidden="true">
-        <div className="absolute top-20 left-20 w-64 h-64 bg-blue-400/20 rounded-full blur-3xl animate-pulse"></div>
-        <div className="absolute bottom-20 right-20 w-80 h-80 bg-purple-400/20 rounded-full blur-3xl animate-pulse delay-1000"></div>
-        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-96 h-96 bg-indigo-400/10 rounded-full blur-3xl animate-pulse delay-2000"></div>
+      <div className="absolute inset-0 opacity-25 pointer-events-none" aria-hidden="true">
+        <div className="absolute top-20 left-20 w-64 h-64 bg-blue-400/20 rounded-full blur-3xl animate-pulse" />
+        <div className="absolute bottom-20 right-20 w-72 h-72 bg-purple-400/20 rounded-full blur-3xl animate-pulse delay-1000" />
       </div>
-      
 
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
-        {/* Section Header */}
+        {/* Header */}
         <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}>
-          <div className="inline-flex items-center space-x-2 bg-blue-100 dark:bg-blue-900/30 px-4 py-2 rounded-full text-blue-600 dark:text-blue-400 text-sm font-medium mb-4">
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-sm font-semibold mb-5">
             <span>📬</span>
-            <span>Get in touch</span>
+            <span>Open to work</span>
           </div>
-          <h2 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+          <h2 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-5">
             <span className="bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
               {CONTACT_ME.title}
             </span>
           </h2>
-          <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+          <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto leading-relaxed">
             {CONTACT_ME.description}
           </p>
-          <div className="w-24 h-1 bg-gradient-to-r from-blue-600 to-purple-600 mx-auto rounded-full mt-6"></div>
+          <div className="w-24 h-1 bg-gradient-to-r from-blue-600 to-purple-600 mx-auto rounded-full mt-6" />
         </div>
 
-        <div className="grid lg:grid-cols-2 gap-12 max-w-6xl mx-auto">
-          {/* Contact Form */}
-          <div className={`transition-all duration-1000 delay-300 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'}`}>
-            <div className="bg-white dark:bg-gray-800 rounded-3xl p-8 shadow-2xl border border-gray-100 dark:border-gray-700 relative overflow-hidden">
-              {/* Form Header */}
-              <div className="mb-8">
-                <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
-                  Send me a message
-                </h3>
-                <p className="text-gray-600 dark:text-gray-300">
-                  I'd love to hear from you. Send me a message and I'll respond as soon as possible.
-                </p>
+        <div className="grid lg:grid-cols-2 gap-10 max-w-6xl mx-auto">
+          {/* Form */}
+          <div className={`transition-all duration-1000 delay-200 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'}`}>
+            <div className="bg-white dark:bg-gray-800 rounded-3xl p-8 shadow-2xl border border-gray-100 dark:border-gray-700">
+              <div className="mb-7">
+                <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-1">Send me a message</h3>
+                <p className="text-sm text-gray-500 dark:text-gray-400">I read every message and reply within 24 hours.</p>
               </div>
 
-              <form onSubmit={handleSubmit} className="space-y-6">
-                {/* Name Field */}
+              <form onSubmit={handleSubmit} className="space-y-5" noValidate>
                 <div className="relative">
-                  <label 
-                    htmlFor="name" 
-                    className={`absolute left-4 transition-all duration-300 pointer-events-none ${
-                      focusedField === 'name' || formData.name 
-                        ? '-top-2 text-xs bg-white dark:bg-gray-800 px-2 text-blue-600 dark:text-blue-400 font-medium' 
-                        : 'top-4 text-gray-500 dark:text-gray-400'
-                    }`}
-                  >
-                    Your Name
-                  </label>
-                  <input
-                    type="text"
-                    id="name"
-                    name="name"
-                    value={formData.name}
-                    onChange={handleChange}
-                    onFocus={() => setFocusedField('name')}
-                    onBlur={() => setFocusedField(null)}
-                    className="w-full px-4 py-4 border-2 border-gray-200 dark:border-gray-600 rounded-2xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none transition-all duration-300 hover:border-gray-300 dark:hover:border-gray-500"
-                    required
-                  />
+                  <label htmlFor="name" className={floatingLabel('name', formData.name)}>Your Name</label>
+                  <input type="text" id="name" name="name" value={formData.name} onChange={handleChange}
+                    onFocus={() => setFocusedField('name')} onBlur={() => setFocusedField(null)}
+                    className="w-full px-4 py-4 border-2 border-gray-200 dark:border-gray-600 rounded-2xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none transition-all duration-300"
+                    required />
                 </div>
 
-                {/* Email Field */}
                 <div className="relative">
-                  <label 
-                    htmlFor="email" 
-                    className={`absolute left-4 transition-all duration-300 pointer-events-none ${
-                      focusedField === 'email' || formData.email 
-                        ? '-top-2 text-xs bg-white dark:bg-gray-800 px-2 text-blue-600 dark:text-blue-400 font-medium' 
-                        : 'top-4 text-gray-500 dark:text-gray-400'
-                    }`}
-                  >
-                    Your Email
-                  </label>
-                  <input
-                    type="email"
-                    id="email"
-                    name="email"
-                    value={formData.email}
-                    onChange={handleChange}
-                    onFocus={() => setFocusedField('email')}
-                    onBlur={() => setFocusedField(null)}
-                    className="w-full px-4 py-4 border-2 border-gray-200 dark:border-gray-600 rounded-2xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none transition-all duration-300 hover:border-gray-300 dark:hover:border-gray-500"
-                    required
-                  />
+                  <label htmlFor="email" className={floatingLabel('email', formData.email)}>Your Email</label>
+                  <input type="email" id="email" name="email" value={formData.email} onChange={handleChange}
+                    onFocus={() => setFocusedField('email')} onBlur={() => setFocusedField(null)}
+                    className="w-full px-4 py-4 border-2 border-gray-200 dark:border-gray-600 rounded-2xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none transition-all duration-300"
+                    required />
                 </div>
 
-                {/* Message Field */}
                 <div className="relative">
-                  <label 
-                    htmlFor="message" 
-                    className={`absolute left-4 transition-all duration-300 pointer-events-none ${
-                      focusedField === 'message' || formData.message 
-                        ? '-top-2 text-xs bg-white dark:bg-gray-800 px-2 text-blue-600 dark:text-blue-400 font-medium' 
-                        : 'top-4 text-gray-500 dark:text-gray-400'
-                    }`}
-                  >
-                    Your Message
-                  </label>
-                  <textarea
-                    id="message"
-                    name="message"
-                    rows={5}
-                    value={formData.message}
-                    onChange={handleChange}
-                    onFocus={() => setFocusedField('message')}
-                    onBlur={() => setFocusedField(null)}
-                    className="w-full px-4 py-4 border-2 border-gray-200 dark:border-gray-600 rounded-2xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none transition-all duration-300 hover:border-gray-300 dark:hover:border-gray-500 resize-none"
-                    required
-                  />
+                  <label htmlFor="message" className={floatingLabel('message', formData.message)}>Your Message</label>
+                  <textarea id="message" name="message" rows={5} value={formData.message} onChange={handleChange}
+                    onFocus={() => setFocusedField('message')} onBlur={() => setFocusedField(null)}
+                    className="w-full px-4 py-4 border-2 border-gray-200 dark:border-gray-600 rounded-2xl bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:border-blue-500 dark:focus:border-blue-400 focus:outline-none transition-all duration-300 resize-none"
+                    required />
                 </div>
 
-                {/* Submit Button */}
                 <button
-                  type="submit"
-                  disabled={isSubmitting}
-                  className={`w-full py-4 px-8 rounded-2xl font-semibold text-white text-lg transition-all duration-300 transform hover:scale-105 hover:shadow-xl ${
-                    isSubmitting 
-                      ? 'bg-gray-400 cursor-not-allowed' 
+                  type="submit" disabled={isSubmitting}
+                  className={`w-full py-4 px-8 rounded-2xl font-semibold text-white text-base transition-all duration-300 hover:scale-[1.02] hover:shadow-xl ${
+                    isSubmitting ? 'bg-gray-400 cursor-not-allowed scale-100'
                       : 'bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 shadow-lg hover:shadow-blue-500/25'
                   }`}
                 >
                   {isSubmitting ? (
-                    <div className="flex items-center justify-center space-x-2">
-                      <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
-                      <span>Sending...</span>
+                    <div className="flex items-center justify-center gap-2">
+                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
+                      Sending...
                     </div>
                   ) : (
-                    <div className="flex items-center justify-center space-x-2">
-                      <span>Send Message</span>
-                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div className="flex items-center justify-center gap-2">
+                      {FORMSPREE_ENDPOINT ? 'Send Message' : 'Open Email Client'}
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
                       </svg>
                     </div>
                   )}
                 </button>
 
-                {/* Status Messages */}
                 {submitStatus && (
-                  <div className={`p-4 rounded-2xl text-center font-medium ${
-                    submitStatus === 'success' 
-                      ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' 
+                  <div className={`p-4 rounded-2xl text-center font-medium text-sm ${
+                    submitStatus === 'success'
+                      ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400'
                       : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
                   }`}>
-                    {submitStatus === 'success' 
-                      ? '✅ Message sent successfully! I\'ll get back to you soon.' 
-                      : '❌ Failed to send message. Please try again.'
-                    }
+                    {submitStatus === 'success'
+                      ? "✅ Message sent! I'll get back to you within 24 hours."
+                      : `❌ Something went wrong. Email me directly at ${CONTACT_ME.email}`}
                   </div>
                 )}
               </form>
             </div>
           </div>
 
-          {/* Contact Information & Social Links */}
-          <div className={`space-y-8 transition-all duration-1000 delay-500 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-8'}`}>
-            {/* Quick Contact Info */}
-            <div className="bg-white dark:bg-gray-800 rounded-3xl p-8 shadow-2xl border border-gray-100 dark:border-gray-700">
-              <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
-                Let's connect
-              </h3>
+          {/* Right panel */}
+          <div className={`space-y-6 transition-all duration-1000 delay-400 ${isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-8'}`}>
+            <div className="bg-white dark:bg-gray-800 rounded-3xl p-7 shadow-2xl border border-gray-100 dark:border-gray-700">
+              <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-5">Quick Info</h3>
               <div className="space-y-4">
-                <div className="flex items-center space-x-4">
-                  <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-purple-500 rounded-2xl flex items-center justify-center text-white text-xl">
-                    📍
+                {[
+                  { icon: <Zap className="w-5 h-5" />, color: "from-emerald-500 to-teal-500", label: "Availability", value: CONTACT_ME.availability, pulse: true },
+                  { icon: <Clock className="w-5 h-5" />, color: "from-blue-500 to-indigo-500", label: "Response Time", value: CONTACT_ME.responseTime, pulse: false },
+                  { icon: <MapPin className="w-5 h-5" />, color: "from-purple-500 to-pink-500", label: "Location", value: CONTACT_ME.location, pulse: false },
+                ].map((item, i) => (
+                  <div key={i} className="flex items-start gap-4">
+                    <div className={`w-11 h-11 bg-gradient-to-r ${item.color} rounded-xl flex items-center justify-center text-white flex-shrink-0`}>
+                      {item.icon}
+                    </div>
+                    <div>
+                      <p className="font-semibold text-gray-900 dark:text-white text-sm">{item.label}</p>
+                      <p className="text-gray-600 dark:text-gray-300 text-sm flex items-center gap-1.5 mt-0.5">
+                        {item.pulse && (
+                          <span className="relative flex h-2 w-2">
+                            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                            <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+                          </span>
+                        )}
+                        {item.value}
+                      </p>
+                    </div>
                   </div>
-                  <div>
-                    <p className="font-medium text-gray-900 dark:text-white">Location</p>
-                    <p className="text-gray-600 dark:text-gray-300">Nagpur, Maharashtra, India</p>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-4">
-                  <div className="w-12 h-12 bg-gradient-to-r from-green-500 to-emerald-500 rounded-2xl flex items-center justify-center text-white text-xl">
-                    🕐
-                  </div>
-                  <div>
-                    <p className="font-medium text-gray-900 dark:text-white">Response Time</p>
-                    <p className="text-gray-600 dark:text-gray-300">Usually within 24 hours</p>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-4">
-                  <div className="w-12 h-12 bg-gradient-to-r from-orange-500 to-red-500 rounded-2xl flex items-center justify-center text-white text-xl">
-                    🎯
-                  </div>
-                  <div>
-                    <p className="font-medium text-gray-900 dark:text-white">Availability</p>
-                    <p className="text-gray-600 dark:text-gray-300">Open to new opportunities</p>
-                  </div>
-                </div>
+                ))}
               </div>
             </div>
 
-            {/* Social Links */}
-            <div className="bg-white dark:bg-gray-800 rounded-3xl p-8 shadow-2xl border border-gray-100 dark:border-gray-700">
-              <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
-                Follow me
-              </h3>
-              <div className="grid grid-cols-2 gap-4">
-                {socialLinks.map((social, index) => (
-                  <a
-                    key={social.name}
-                    href={social.href}
-                    target={social.name !== 'Email' ? '_blank' : '_self'}
-                    rel={social.name !== 'Email' ? 'noopener noreferrer' : ''}
-                    className={`group relative p-6 rounded-2xl bg-gradient-to-r ${social.color} text-white hover:scale-105 transform transition-all duration-300 hover:shadow-xl overflow-hidden`}
+            <div className="bg-white dark:bg-gray-800 rounded-3xl p-7 shadow-2xl border border-gray-100 dark:border-gray-700">
+              <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-5">Find me on</h3>
+              <div className="space-y-3">
+                {socialLinks.map((social) => (
+                  <a key={social.name} href={social.href}
+                    target={social.external ? '_blank' : '_self'}
+                    rel={social.external ? 'noopener noreferrer' : undefined}
+                    className={`flex items-center gap-4 p-4 rounded-2xl bg-gradient-to-r ${social.color} text-white hover:scale-[1.02] transform transition-all duration-300 hover:shadow-lg group`}
                   >
-                    <div className="relative z-10">
-                      <div className="text-2xl mb-2">{social.icon}</div>
-                      <div className="font-semibold text-lg">{social.name}</div>
-                      <div className="text-sm opacity-90">{social.description}</div>
+                    <div className="flex-shrink-0">{social.icon}</div>
+                    <div className="min-w-0">
+                      <p className="font-semibold text-sm">{social.name}</p>
+                      <p className="text-xs opacity-80 truncate">{social.description}</p>
                     </div>
-                    <div className="absolute inset-0 bg-white/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                    <div className="ml-auto opacity-60 group-hover:opacity-100 transition-opacity">
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                      </svg>
+                    </div>
                   </a>
                 ))}
               </div>
             </div>
 
-            {/* Fun Quote */}
             <div className="relative">
-              <div className="absolute inset-0 bg-gradient-to-r from-blue-400 to-purple-400 rounded-3xl transform rotate-1 opacity-20"></div>
-              <div className="relative bg-white dark:bg-gray-800 rounded-3xl p-8 shadow-2xl border border-gray-100 dark:border-gray-700 text-center">
-                <div className="text-4xl mb-4">💡</div>
-                <p className="text-lg font-medium text-gray-900 dark:text-white mb-2">
-                  "The best way to predict the future is to create it."
-                </p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  - Peter Drucker
-                </p>
+              <div className="absolute inset-0 bg-gradient-to-r from-blue-400 to-purple-400 rounded-3xl rotate-1 opacity-15" />
+              <div className="relative bg-white dark:bg-gray-800 rounded-3xl p-6 shadow-xl border border-gray-100 dark:border-gray-700 text-center">
+                <div className="text-3xl mb-3">🤝</div>
+                <p className="text-gray-900 dark:text-white font-bold mb-1">Let&apos;s make something great</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">Whether it&apos;s a job, contract, or just a great conversation — I&apos;m in.</p>
               </div>
             </div>
           </div>

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -4,88 +4,40 @@ import { motion, useInView } from 'framer-motion';
 import Image from 'next/image';
 import { SKILLS } from '../../lib/constants';
 
-const SkillCategory = ({ title, skills, isInView }) => {
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.1,
-        delayChildren: 0.2,
-      },
-    },
-  };
-
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20, scale: 0.95 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      scale: 1,
-      transition: { duration: 0.5, ease: [0.0, 0.0, 0.2, 1] as const },
-    },
-  };
-
-  return (
-    <motion.div
-      className="w-full md:w-1/2 lg:w-1/4 p-4"
-      initial={{ opacity: 0, y: 50 }}
-      animate={isInView ? { opacity: 1, y: 0 } : {}}
-      transition={{ duration: 0.7, ease: 'easeOut' }}
-    >
-      <h3 className="text-3xl font-bold text-gray-900 dark:text-white mb-8 text-center">
-        <span className="bg-gradient-to-r from-blue-500 to-purple-500 bg-clip-text text-transparent">
-          {title}
-        </span>
-      </h3>
-      <motion.div
-        className="grid grid-cols-2 sm:grid-cols-3 gap-6"
-        variants={containerVariants}
-        initial="hidden"
-        animate={isInView ? 'visible' : 'hidden'}
-      >
-        {skills.map((skill) => (
-          <motion.div
-            key={skill.name}
-            className="group flex flex-col items-center justify-center p-6 bg-white/60 dark:bg-gray-800/60 backdrop-blur-xl rounded-2xl shadow-lg hover:shadow-2xl border border-gray-200 dark:border-gray-700 transition-all duration-300 transform hover:-translate-y-2 hover:scale-105"
-            variants={itemVariants}
-          >
-            <div className="relative w-16 h-16 mb-4 transition-transform duration-300 group-hover:scale-110">
-              <div className="absolute inset-0 bg-gradient-to-br from-blue-400 to-purple-400 rounded-full blur-lg opacity-20 group-hover:opacity-40 transition-opacity duration-300" aria-hidden="true"></div>
-              <Image
-                src={skill.icon}
-                alt={skill.name}
-                width={64}
-                height={64}
-                className="relative object-contain p-2 bg-white/80 dark:bg-gray-900/80 rounded-full shadow-md"
-              />
-            </div>
-            <p className="text-gray-800 dark:text-gray-200 text-center text-sm font-semibold">
-              {skill.name}
-            </p>
-          </motion.div>
-        ))}
-      </motion.div>
-    </motion.div>
-  );
-};
+const fadeUp = (delay = 0) => ({
+  hidden: { opacity: 0, y: 24 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.55, ease: [0.0, 0.0, 0.2, 1] as const, delay },
+  },
+});
 
 const Skills = () => {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.1 });
 
   return (
-    <section 
-      id="skills" 
+    <section
+      id="skills"
       ref={ref}
-      className="py-24 bg-gradient-to-br from-white/80 via-gray-50/80 to-blue-100/80 dark:from-gray-900/80 dark:via-slate-900/80 dark:to-black/80 relative overflow-hidden"
+      className="py-24 bg-gradient-to-br from-white/80 via-gray-50/80 to-blue-50/80 dark:from-gray-900/80 dark:via-slate-900/80 dark:to-black/80 relative overflow-hidden"
     >
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <motion.div 
+      <div
+        className="absolute inset-0 opacity-[0.03] dark:opacity-[0.06] pointer-events-none"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%236366f1' fill-opacity='1'%3E%3Ccircle cx='20' cy='20' r='1'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
+        }}
+        aria-hidden="true"
+      />
+
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+        {/* Header */}
+        <motion.div
           className="text-center mb-16"
-          initial={{ opacity: 0, y: -50 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.8, ease: 'easeOut' }}
+          variants={fadeUp(0)}
+          initial="hidden"
+          animate={isInView ? 'visible' : 'hidden'}
         >
           <div className="inline-flex items-center space-x-2 bg-blue-100 dark:bg-blue-900/30 px-4 py-2 rounded-full text-blue-600 dark:text-blue-400 text-sm font-medium mb-4">
             <span>🛠️</span>
@@ -97,16 +49,105 @@ const Skills = () => {
             </span>
           </h2>
           <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-            A collection of technologies and tools I use to bring ideas to life.
+            {SKILLS.subtitle}
           </p>
-          <div className="w-24 h-1 bg-gradient-to-r from-blue-600 to-purple-600 mx-auto rounded-full mt-6"></div>
+          <div className="w-24 h-1 bg-gradient-to-r from-blue-600 to-purple-600 mx-auto rounded-full mt-6" />
         </motion.div>
-        <div className="flex flex-wrap justify-center -mx-4">
-          <SkillCategory title="Frontend" skills={SKILLS.frontend} isInView={isInView} />
-          <SkillCategory title="Backend" skills={SKILLS.backend} isInView={isInView} />
-          <SkillCategory title="QA Automation" skills={SKILLS.qaAutomation} isInView={isInView} />
-          <SkillCategory title="DevOps" skills={SKILLS.devops} isInView={isInView} />
-        </div>
+
+        {/* ── Tier 1: Core Stack ── */}
+        <motion.div
+          variants={fadeUp(0.1)}
+          initial="hidden"
+          animate={isInView ? 'visible' : 'hidden'}
+          className="mb-14"
+        >
+          <div className="flex items-center gap-3 mb-6">
+            <span className="text-xs font-bold tracking-widest uppercase text-gray-400 dark:text-gray-500">Core Stack</span>
+            <div className="flex-1 h-px bg-gradient-to-r from-blue-200 to-transparent dark:from-blue-800" />
+            <span className="text-xs text-gray-400 dark:text-gray-500 font-medium">Ship with daily</span>
+          </div>
+          <div className="grid grid-cols-3 sm:grid-cols-6 gap-3 sm:gap-4">
+            {SKILLS.core.map((skill, i) => (
+              <motion.div
+                key={skill.name}
+                className="group flex flex-col items-center justify-center gap-3 p-4 sm:p-5 bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm hover:shadow-xl hover:-translate-y-1.5 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-300"
+                variants={fadeUp(0.15 + i * 0.05)}
+                initial="hidden"
+                animate={isInView ? 'visible' : 'hidden'}
+              >
+                <div className="relative w-10 h-10 sm:w-12 sm:h-12 flex-shrink-0">
+                  <div className="absolute inset-0 bg-gradient-to-br from-blue-400 to-purple-400 rounded-full blur-md opacity-0 group-hover:opacity-30 transition-opacity duration-300" aria-hidden="true" />
+                  <Image src={skill.icon} alt={skill.name} width={48} height={48} className="relative w-full h-full object-contain" />
+                </div>
+                <p className="text-gray-800 dark:text-gray-200 text-xs sm:text-sm font-semibold text-center leading-tight">{skill.name}</p>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+
+        {/* ── Tier 2: Proficient ── */}
+        <motion.div
+          variants={fadeUp(0.2)}
+          initial="hidden"
+          animate={isInView ? 'visible' : 'hidden'}
+          className="mb-14"
+        >
+          <div className="flex items-center gap-3 mb-6">
+            <span className="text-xs font-bold tracking-widest uppercase text-gray-400 dark:text-gray-500">Proficient</span>
+            <div className="flex-1 h-px bg-gradient-to-r from-purple-200 to-transparent dark:from-purple-800" />
+            <span className="text-xs text-gray-400 dark:text-gray-500 font-medium">Production-proven</span>
+          </div>
+          <div className="grid grid-cols-4 sm:grid-cols-7 gap-3">
+            {SKILLS.proficient.map((skill, i) => (
+              <motion.div
+                key={skill.name}
+                className="group flex flex-col items-center justify-center gap-2 p-3 sm:p-4 bg-white/70 dark:bg-gray-800/70 rounded-xl border border-gray-200/80 dark:border-gray-700/80 hover:shadow-lg hover:-translate-y-1 hover:border-purple-300 dark:hover:border-purple-600 transition-all duration-300"
+                variants={fadeUp(0.25 + i * 0.04)}
+                initial="hidden"
+                animate={isInView ? 'visible' : 'hidden'}
+              >
+                <div className="relative w-8 h-8 flex-shrink-0">
+                  <Image src={skill.icon} alt={skill.name} width={32} height={32} className="w-full h-full object-contain" />
+                </div>
+                <p className="text-gray-700 dark:text-gray-300 text-[10px] sm:text-xs font-medium text-center leading-tight">{skill.name}</p>
+              </motion.div>
+            ))}
+          </div>
+        </motion.div>
+
+        {/* ── Tier 3: Testing & DevOps Tools ── */}
+        <motion.div
+          variants={fadeUp(0.3)}
+          initial="hidden"
+          animate={isInView ? 'visible' : 'hidden'}
+        >
+          <div className="flex items-center gap-3 mb-6">
+            <span className="text-xs font-bold tracking-widest uppercase text-gray-400 dark:text-gray-500">Testing &amp; DevOps Tools</span>
+            <div className="flex-1 h-px bg-gradient-to-r from-emerald-200 to-transparent dark:from-emerald-800" />
+          </div>
+          <div className="flex flex-wrap gap-2 sm:gap-3">
+            {SKILLS.tools.map((tool, i) => (
+              <motion.span
+                key={tool}
+                className="inline-flex items-center px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-xs sm:text-sm font-medium border border-gray-200 dark:border-gray-700 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:border-blue-300 dark:hover:border-blue-700 hover:text-blue-700 dark:hover:text-blue-300 transition-all duration-200 cursor-default"
+                variants={fadeUp(0.35 + i * 0.03)}
+                initial="hidden"
+                animate={isInView ? 'visible' : 'hidden'}
+              >
+                {tool}
+              </motion.span>
+            ))}
+          </div>
+        </motion.div>
+
+        <motion.p
+          className="text-center text-sm text-gray-400 dark:text-gray-500 mt-12 max-w-lg mx-auto"
+          variants={fadeUp(0.6)}
+          initial="hidden"
+          animate={isInView ? 'visible' : 'hidden'}
+        >
+          Core stack shipped to production for 3+ years at scale — not tutorial projects.
+        </motion.p>
       </div>
     </section>
   );

--- a/src/components/shared/AvailabilityBar.tsx
+++ b/src/components/shared/AvailabilityBar.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+
+const AvailabilityBar = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const dismissed = sessionStorage.getItem("availability-bar-dismissed");
+    if (!dismissed) setVisible(true);
+  }, []);
+
+  const dismiss = () => {
+    sessionStorage.setItem("availability-bar-dismissed", "1");
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="fixed top-0 left-0 right-0 z-[60] h-9 flex items-center justify-center gap-3 px-4
+                 bg-gradient-to-r from-emerald-600 via-teal-600 to-emerald-600
+                 dark:from-emerald-700 dark:via-teal-700 dark:to-emerald-700
+                 text-white text-xs font-medium shadow-sm"
+      role="banner"
+    >
+      <span className="relative flex h-2 w-2 flex-shrink-0" aria-hidden="true">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-60" />
+        <span className="relative inline-flex rounded-full h-2 w-2 bg-white" />
+      </span>
+      <span className="hidden sm:inline truncate">
+        Available for new opportunities &nbsp;·&nbsp; Nagpur, India &nbsp;·&nbsp; Replies within 24h
+      </span>
+      <span className="sm:hidden truncate">Open to opportunities · Nagpur, India</span>
+      <a
+        href="#contact"
+        onClick={dismiss}
+        className="hidden sm:inline-flex items-center gap-1 px-3 py-1 rounded-full bg-white/20 hover:bg-white/30 transition-colors duration-200 font-semibold flex-shrink-0"
+      >
+        Get in touch →
+      </a>
+      <button
+        onClick={dismiss}
+        className="absolute right-3 p-1 rounded-full hover:bg-white/20 transition-colors duration-200"
+        aria-label="Dismiss availability bar"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+};
+
+export default AvailabilityBar;

--- a/src/components/shared/MobileBottomNav.tsx
+++ b/src/components/shared/MobileBottomNav.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useEffect, useState, useCallback } from "react";
+import { Briefcase, Code2, User, Mail } from "lucide-react";
+
+const tabs = [
+  { label: "About",    href: "#about",    icon: User },
+  { label: "Skills",   href: "#skills",   icon: Code2 },
+  { label: "Projects", href: "#projects", icon: Briefcase },
+  { label: "Contact",  href: "#contact",  icon: Mail },
+];
+
+const MobileBottomNav = () => {
+  const [activeTab, setActiveTab] = useState("about");
+
+  useEffect(() => {
+    const ids = tabs.map(t => t.href.substring(1));
+    const onScroll = () => {
+      let current = ids[0];
+      ids.forEach(id => {
+        const el = document.getElementById(id);
+        if (el && window.scrollY >= el.offsetTop - 200) current = id;
+      });
+      setActiveTab(current);
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const navigate = useCallback((href: string) => {
+    document.querySelector(href)?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  return (
+    <nav
+      className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-900/90 backdrop-blur-xl border-t border-gray-200 dark:border-gray-800 shadow-[0_-4px_24px_rgba(0,0,0,0.08)] dark:shadow-[0_-4px_24px_rgba(0,0,0,0.3)]"
+      aria-label="Mobile navigation"
+    >
+      <div className="flex items-stretch pb-safe">
+        {tabs.map(({ label, href, icon: Icon }) => {
+          const id = href.substring(1);
+          const isActive = activeTab === id;
+          return (
+            <button
+              key={href}
+              onClick={() => navigate(href)}
+              aria-label={`Navigate to ${label}`}
+              aria-current={isActive ? "page" : undefined}
+              className="flex-1 flex flex-col items-center justify-center gap-1 py-3 relative group transition-colors duration-200"
+            >
+              {isActive && (
+                <span className="absolute top-0 left-1/2 -translate-x-1/2 w-10 h-0.5 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full" aria-hidden="true" />
+              )}
+              <Icon
+                className={`w-5 h-5 transition-all duration-200 ${
+                  isActive ? "text-blue-600 dark:text-blue-400 scale-110" : "text-gray-400 dark:text-gray-500 group-hover:text-gray-600 dark:group-hover:text-gray-300"
+                }`}
+                strokeWidth={isActive ? 2.5 : 1.8}
+              />
+              <span className={`text-[10px] font-semibold leading-none transition-colors duration-200 ${
+                isActive ? "text-blue-600 dark:text-blue-400" : "text-gray-400 dark:text-gray-500 group-hover:text-gray-600 dark:group-hover:text-gray-300"
+              }`}>
+                {label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};
+
+export default MobileBottomNav;

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -46,7 +46,7 @@ const Navbar = () => {
   // Navbar CSS classes
   const navbarClasses = useMemo(
     () =>
-      `fixed top-0 z-50 w-full transition-transform duration-500 ease-in-out mt-5 rounded-full
+      `fixed top-0 z-50 w-full transition-transform duration-500 ease-in-out mt-[44px] rounded-full
       ${isVisible ? "translate-y-0" : "-translate-y-[120%]"}
       ${isScrolled ? "backdrop-blur-3xl bg-opacity-140" : ""}`,
     [isVisible, isScrolled]

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,75 +1,113 @@
 export const SITE_METADATA = {
-  title: "Samir Kadu - Professional Portfolio",
-  description: "Samir Kadu's professional portfolio showcasing his skills, projects, and experience in software development.",
+  title: "Samir Kadu — Full Stack Engineer & QA Automation Specialist",
+  description:
+    "Samir Kadu builds reliable, production-grade web applications and automated test systems. 3+ years at Bajaj Finserv Health. AWS Certified.",
   author: "Samir Kadu",
-  keywords: "Samir Kadu, portfolio, developer, software engineer, web developer, frontend, backend, QA automation, DevOps, Next.js, React, Tailwind CSS, Framer Motion",
-  url: "https://www.samirkadu.com", // Replace with actual domain
-  image: "/og-image.jpg", // Replace with actual OG image
+  keywords:
+    "Samir Kadu, Full Stack Developer, QA Automation Engineer, React, Next.js, TypeScript, Spring Boot, Selenium, Playwright, AWS, Bajaj Finserv Health, portfolio",
+  url: "https://www.samirkadu.com",
+  image: "/og-image.jpg",
 };
 
 export const NAV_LINKS = [
-  { name: "Home", href: "#hero" },
   { name: "About", href: "#about" },
   { name: "Skills", href: "#skills" },
   { name: "Projects", href: "#projects" },
   { name: "Experience", href: "#experience" },
-  { name: "Interests", href: "#interests" },
   { name: "Contact", href: "#contact" },
 ];
 
 export const HERO_SECTION = {
   name: "Samir Kadu",
-  tagline: "Full Stack Developer | QA Automation Engineer",
-  introText: "Passionate about crafting innovative solutions and building seamless user experiences.",
-  avatar: "/images/samir-avatar.png", // Placeholder
+  badge: "Software Engineer @ Bajaj Finserv Health",
+  availabilityBadge: "Open to opportunities",
+  tagline: "I build software that scales — then I make sure it never breaks.",
+  roles: [
+    "Full Stack Engineer",
+    "Automation Specialist",
+    "AWS Certified Engineer",
+  ],
+  introText:
+    "3+ years shipping production health-tech to hundreds of thousands of users. I own features end-to-end — architecture, implementation, automated testing, and zero-defect deployment.",
+  quickStats: [
+    { value: "3+", label: "Years in Production" },
+    { value: "25+", label: "Features Shipped" },
+    { value: "AWS", label: "Certified" },
+  ],
+  avatar: "/images/samir-avatar.png",
   ctaButtons: [
+    { text: "View My Work", link: "#projects", type: "scroll" },
     { text: "Download Resume", link: "/Samir_Kadu_Resume.pdf", type: "download" },
-    { text: "Let's Connect", link: "#contact", type: "scroll" },
   ],
 };
 
 export const ABOUT_ME = {
   title: "About Me",
-  story: "Hello! I'm Samir Kadu, a passionate and dedicated software engineer with a knack for building robust and scalable applications. My journey in tech began with a fascination for how things work, leading me to explore various domains from frontend development to QA automation and DevOps. I thrive on solving complex problems and continuously learning new technologies to deliver high-quality solutions.",
-  goals: "My goal is to leverage my skills to create impactful software that not only meets user needs but also pushes the boundaries of innovation. I am always eager to collaborate on challenging projects and contribute to a team that values creativity and excellence.",
-  passion: "Beyond coding, I am deeply passionate about understanding emerging technologies like AI and ML, and exploring their potential to transform industries. I also enjoy delving into the world of trading and understanding market dynamics.",
+  story:
+    "Full Stack Engineer with 3+ years building production health-tech at Bajaj Finserv Health — one of India's leading digital health platforms. I own features end-to-end: system design, implementation, test automation, and deployment.\n\nMy edge: I treat quality as a first-class feature, not an afterthought. As the QA-embedded engineer across multiple agile squads, I'm the bridge between product spec, engineering, and what actually ships.",
+  goals:
+    "I want to work on products that actually matter — solving hard technical problems with real-world impact. Whether that's a high-scale platform, a fintech product, or a startup building something new, I bring both engineering depth and a quality-first mindset.\n\nNext goal: an engineering role where I can lead feature development end-to-end and help build a culture of technical excellence.",
+  passion:
+    "I'm obsessed with the intersection of software reliability and developer experience. Automated testing, clean architecture, and well-documented APIs aren't just nice-to-haves for me — they're the baseline.\n\nOutside code, I follow financial markets, explore AI/ML research, and read obsessively about startups and product strategy. I believe the best engineers are also strong product thinkers.",
+  currentFocus: [
+    { label: "Currently", value: "Building automation infra @ Bajaj Finserv Health" },
+    { label: "Studying", value: "System design & distributed systems architecture" },
+    { label: "Open to", value: "Senior SWE · Lead QA · Fintech / Healthtech · Remote" },
+  ],
+  interests:
+    "Outside engineering: algorithmic trading strategies, AI/ML research, startup product thinking, and reading everything I can about how great software teams work.",
+  stats: [
+    { label: "Years in Production", value: "3+", icon: "🚀" },
+    { label: "Features Shipped", value: "25+", icon: "💼" },
+    { label: "Technologies", value: "15+", icon: "⚡" },
+    { label: "Test Suites Built", value: "10+", icon: "✅" },
+  ],
+  highlights: [
+    { icon: "🏗️", text: "End-to-end feature ownership" },
+    { icon: "🔍", text: "Quality-first engineering mindset" },
+    { icon: "📈", text: "Production-proven at scale" },
+    { icon: "🤝", text: "Cross-functional collaborator" },
+  ],
+  quote: {
+    text: "First, solve the problem. Then, write the code.",
+    author: "John Johnson",
+  },
 };
 
 export const SKILLS = {
-  title: "Skills & Knowledge",
-  frontend: [
+  title: "Skills & Expertise",
+  subtitle: "Technologies I use to build, test, and ship production software",
+  core: [
     { name: "React", icon: "/icons/react.svg" },
-    { name: "Next.js", icon: "/icons/nextjs.svg" },
     { name: "TypeScript", icon: "/icons/typescript.svg" },
-    { name: "JavaScript", icon: "/icons/javascript.svg" },
-    { name: "HTML5", icon: "/icons/html5.svg" },
-    { name: "CSS3", icon: "/icons/css3.svg" },
-    { name: "Tailwind CSS", icon: "/icons/tailwind.svg" },
-    { name: "Bootstrap", icon: "/icons/bootstrap.svg" },
-  ],
-  backend: [
     { name: "Node.js", icon: "/icons/nodejs.svg" },
-    { name: "Express.js", icon: "/icons/express.svg" },
     { name: "Python", icon: "/icons/python.svg" },
+    { name: "Java", icon: "/icons/java.svg" },
+    { name: "JavaScript", icon: "/icons/javascript.svg" },
+  ],
+  proficient: [
     { name: "Django", icon: "/icons/django.svg" },
     { name: "Flask", icon: "/icons/flask.svg" },
+    { name: "Express.js", icon: "/icons/express.svg" },
     { name: "SQL", icon: "/icons/sql.svg" },
     { name: "MongoDB", icon: "/icons/mongodb.svg" },
-    { name: "Java", icon: "/icons/java.svg" },
-  ],
-  qaAutomation: [
-    { name: "Selenium", icon: "/icons/selenium.svg" },
-    { name: "Cypress", icon: "/icons/cypress.svg" },
-    { name: "Playwright", icon: "/icons/playwright.svg" },
-    { name: "Jira", icon: "/icons/jira.svg" },
-    { name: "TestRail", icon: "/icons/testrail.svg" },
-  ],
-  devops: [
-    { name: "Docker", icon: "/icons/docker.svg" },
-    { name: "Kubernetes", icon: "/icons/kubernetes.svg" },
     { name: "AWS", icon: "/icons/aws.svg" },
-    { name: "Git", icon: "/icons/git.svg" },
-    { name: "Jenkins", icon: "/icons/jenkins.svg" },
+    { name: "Docker", icon: "/icons/docker.svg" },
+  ],
+  tools: [
+    "Next.js",
+    "Playwright",
+    "Selenium",
+    "Cypress",
+    "TestRail",
+    "Jira",
+    "Git",
+    "Jenkins",
+    "Kubernetes",
+    "Bootstrap",
+    "Tailwind CSS",
+    "HTML5",
+    "CSS3",
   ],
 };
 
@@ -77,10 +115,17 @@ export const PROJECTS = [
   {
     id: 1,
     title: "Go_Bus",
+    tagline: "Full-stack bus booking SaaS with multi-role access control",
     description:
-      "An online bus ticket booking platform with panels for Admin, Operator, and User. Features include bus approval, route management, and customer feedback handling.",
+      "End-to-end bus ticket booking system with dedicated panels for Admin, Operator, and User roles. Built with Spring Boot REST APIs, JWT authentication, and a React frontend.",
+    problem:
+      "Bus operators lacked a unified digital system — bookings were manual, route management was scattered, and there was no way for admins to oversee the ecosystem at scale.",
+    solution:
+      "Designed and built a multi-role SaaS platform from scratch. Operators manage routes and schedules. Admins approve operators and monitor activity. Users browse, book, and manage tickets — all secured with JWT-based auth.",
+    impact:
+      "Replaced 100% of the manual booking workflow. Supports real-time seat availability across multiple operators. Multi-role architecture designed to onboard N operators without code changes.",
     techStack: ["React", "Spring Boot", "MySQL", "JWT Auth"],
-    image: "/images/go-bus.png", // Placeholder
+    image: "/images/go-bus.png",
     githubLink: "https://github.com/Sameer-Kadu/Go_Bus.git",
     demoLink: "https://go-bus-oarm.vercel.app/",
     category: "work",
@@ -88,17 +133,22 @@ export const PROJECTS = [
   {
     id: 2,
     title: "Cultural Tourism Explorer",
+    tagline: "Hackathon winner — data storytelling for India's cultural heritage",
     description:
-      "A data-driven storytelling platform created for the Snowflake | YourStory Hero Hackathon. It bridges art, culture, and tourism by showcasing traditional experiences across India using interactive visuals.",
+      "A data-driven platform built for the Snowflake × YourStory Hero Hackathon. Bridges art, culture, and tourism across India through interactive data visualizations. Built in 48 hours.",
+    problem:
+      "India's rich cultural and tourism data was scattered across sources with no unified, engaging interface for exploration or storytelling.",
+    solution:
+      "Built a data pipeline from Snowflake's cloud data warehouse into a Streamlit app, using Python and Pandas for transformation, with interactive charts for regional exploration.",
+    impact:
+      "Selected among top submissions by Snowflake & YourStory judges for data engineering quality and visual storytelling. Built in 48 hours. Live demo deployed and publicly accessible.",
     techStack: ["Snowflake", "Streamlit", "Python", "Pandas"],
-    image: "/images/tourism-hackathon.png", // Placeholder
-    githubLink: "https://github.com/Sameer-Kadu/snowflake-hero-challenge.git", // Replace if different
-    demoLink: "https://wanderwiseindia.streamlit.app/", // Replace if different
+    image: "/images/tourism-hackathon.png",
+    githubLink: "https://github.com/Sameer-Kadu/snowflake-hero-challenge.git",
+    demoLink: "https://wanderwiseindia.streamlit.app/",
     category: "hackathon",
   },
 ];
-
-
 
 export const EXPERIENCE_EDUCATION = {
   title: "Experience & Education",
@@ -107,75 +157,66 @@ export const EXPERIENCE_EDUCATION = {
       type: "experience",
       title: "Software Engineer",
       company: "Bajaj Finserv Health",
-      duration: "Jan 2023 - Present",
+      duration: "Jan 2023 – Present",
       description:
-        "Developed and maintained various features for their health tech platform, focusing on performance and scalability.",
-      icon: "💼", // ✅ added
+        "Building and owning features for a digital health platform serving hundreds of thousands of users. Work spans full-stack development, REST API design, and production-grade QA automation.",
+      highlights: [
+        "Designed and shipped 10+ production features across patient appointments, health records, and provider dashboard flows",
+        "Built 10+ end-to-end automated test suites with Playwright & Selenium — cutting regression cycle time from days to hours and eliminating manual QA sprints per release",
+        "Designed REST APIs now consumed by 3+ internal frontend products covering core health-tech workflows",
+        "Embedded QA engineer across 4+ agile squads — primary bridge between product spec, engineering implementation, and release quality gates",
+        "Containerized services with Docker, standardizing dev-to-prod environment parity and eliminating environment-specific bugs",
+      ],
+      icon: "💼",
     },
     {
       type: "education",
       title: "Post Graduate Diploma in Advanced Computing (PG-DAC)",
       institution: "CDAC",
-      duration: "Aug 2022 - Jan 2023",
+      duration: "Aug 2022 – Jan 2023",
       description:
-        "Completed an intensive program covering full-stack development, data structures, and algorithms.",
-      icon: "🎓", // ✅ added
+        "Intensive 6-month industry-oriented program covering full-stack development, data structures, algorithms, operating systems, and software engineering practices.",
+      highlights: [
+        "Covered Java, C++, .NET, Python, and database engineering in depth under exam pressure",
+        "Capstone: full-stack Java Spring Boot + React app, delivered end-to-end in a team setting",
+        "Ranked among top performers in the batch",
+      ],
+      icon: "🎓",
     },
     {
       type: "certification",
       title: "AWS Certified Solutions Architect – Associate",
-      institution: "Amazon Web Services (AWS)",
+      institution: "Amazon Web Services",
       duration: "May 2023",
-      description: "Certified in designing distributed systems on AWS.",
-      icon: "📜", // ✅ added
+      description:
+        "Validated expertise in designing distributed, fault-tolerant systems on AWS — covering compute, storage, networking, security, and cost optimization.",
+      highlights: [
+        "Certified in designing cloud-native, fault-tolerant architectures on AWS",
+        "Covers EC2, S3, RDS, VPC, IAM, Lambda, and Auto Scaling in production contexts",
+        "Demonstrates cloud-first engineering mindset backed by formal validation",
+      ],
+      icon: "📜",
     },
   ],
 };
 
-
+// Kept for reference — section removed from page, content condensed into AboutMe
 export const INTERESTS_HOBBIES = {
-  title: "Interests & Hobbies",
-  items: [
-  {
-    name: "Trading",
-    icon: "/icons/trading.svg",
-    description: "Passionate about financial markets and algorithmic trading. I explore patterns, backtest strategies, and build trading systems to stay ahead in the game."
-  },
-  {
-    name: "Startups",
-    icon: "/icons/startup.svg",
-    description: "Inspired by innovation and solving real-world problems, I love brainstorming startup ideas and turning tech concepts into scalable solutions."
-  },
-  {
-    name: "Artificial Intelligence",
-    icon: "/icons/ai.svg",
-    description: "AI fascinates me — from neural networks to intelligent automation. I enjoy learning how machines think and apply that to building smarter applications."
-  },
-  {
-    name: "Machine Learning",
-    icon: "/icons/ml.svg",
-    description: "Exploring ML algorithms, data models, and their practical applications excites me. I often experiment with real-world datasets to deepen my understanding."
-  },
-  {
-    name: "Reading",
-    icon: "/icons/reading.svg",
-    description: "I enjoy reading non-fiction, especially tech blogs, startup stories, and books on personal growth and decision-making."
-  },
-  {
-    name: "Traveling",
-    icon: "/icons/travel.svg",
-    description: "Traveling helps me recharge and gain new perspectives. I find inspiration in different cultures, landscapes, and stories from around the world."
-  }
-]
-
+  title: "Beyond the Code",
+  subtitle: "What keeps me sharp outside of engineering",
+  items: [] as { name: string; icon: string; description: string }[],
 };
 
 export const CONTACT_ME = {
-  title: "Get in Touch",
-  description: "Have a question or want to work together? Feel free to reach out!",
-  email: "samirkadu8@gmail.com", // Replace with actual email
-  linkedin: "https://www.linkedin.com/in/sameer-kadu/", // Replace with actual LinkedIn
-  github: "https://github.com/Sameer-Kadu", // Replace with actual GitHub
+  title: "Let's Build Something Together",
+  description:
+    "Have a role, project, or idea in mind? I'm actively exploring new opportunities in full-stack engineering and automation. Let's talk — I respond within 24 hours.",
+  availability: "Actively looking — open to full-time & freelance",
+  responseTime: "Replies within 24 hours",
+  location: "Nagpur, Maharashtra, India",
+  email: "samirkadu8@gmail.com",
+  linkedin: "https://www.linkedin.com/in/sameer-kadu/",
+  github: "https://github.com/Sameer-Kadu",
 };
 
-export const FOOTER_TEXT = "© 2024 Samir Kadu. All rights reserved.";
+export const FOOTER_TEXT = `© ${new Date().getFullYear()} Samir Kadu. All rights reserved.`;


### PR DESCRIPTION
- Skills: replaced icon-soup grid with 3-tier layout (Core / Proficient / Tools pills)
- About: removed hidden tab UI, replaced with always-visible bento grid + "Right Now" status block
- Contact: wired real Formspree form submission (was fake setTimeout mock)
- Nav: trimmed from 7 items to 5 (removed Home + Interests)
- Interests section removed from page; content folded into About
- New AvailabilityBar: fixed green banner showing open-to-work status
- New MobileBottomNav: fixed bottom tab bar for mobile (lg:hidden)
- Navbar offset updated (mt-[44px]) to sit below availability bar
- globals.css: merged hamburger + nav-glow styles, added iOS safe-area support
- layout.tsx: updated metadata, wired new components, removed dead import
- constants.ts: rewrote experience highlights with specifics, project impacts, nav links
- .env.local.example: Formspree setup instructions